### PR TITLE
Add error raising

### DIFF
--- a/psrdb/graphql_client.py
+++ b/psrdb/graphql_client.py
@@ -47,6 +47,7 @@ class GraphQLClient:
             if "message" in content["errors"][0]:
                 message = content["errors"][0]["message"]
             self.logger.error(f"Error: {message}")
+            raise Exception(f"Error: {message}")
 
     def post(self, payload):
         """Post the payload and header to the GraphQL URL."""

--- a/psrdb/graphql_table.py
+++ b/psrdb/graphql_table.py
@@ -118,9 +118,11 @@ class GraphQLTable:
                     else:
                         print(created_data["id"])
             else:
-                self.logger.warning(f"Errors returned in content {content['errors']}")
+                self.logger.error(f"Errors returned in content {content['errors']}")
+                raise Exception(f"Errors returned in content {content['errors']}")
         else:
-            self.logger.warning(f"Bad response status_code={response.status_code}")
+            self.logger.error(f"Bad response status_code={response.status_code}")
+            raise Exception(f"Bad response status_code={response.status_code}")
         return None
 
     def mutation_graphql(self):
@@ -194,7 +196,12 @@ class GraphQLTable:
                             result.append(node["node"])
                         self.print_record_set(node["node"], "\t", print_headers=print_headers)
                         print_headers = cursor is None
-
+                else:
+                    self.logger.error(f"Errors returned in content {content['errors']}")
+                    raise Exception(f"Errors returned in content {content['errors']}")
+            else:
+                self.logger.error(f"Bad response status_code={response.status_code}")
+                raise Exception(f"Bad response status_code={response.status_code}")
         if self.get_dicts:
             return result
         else:


### PR DESCRIPTION
No error raising in` list_graphql `meant that if a Seqera MeerPipe job failed at the `OBS_LIST` stage, it could be recorded as completed. So I added error raising there.
I though I'd add it everywhere else too but not sure if that's going to cause unnecessary/numerous job fails if some errors should stay silent. Can modify if that happens.